### PR TITLE
Lazy-load non-critical sections and defer profile image to improve first load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,20 @@
-import { useState, useEffect } from 'react';
+import { Suspense, lazy, useEffect, useState } from 'react';
 import './App.css';
 import Header from './components/Header';
 import Hero from './components/Hero';
 import About from './components/About';
-import Experience from './components/Experience';
-import CoreCompetencies from './components/CoreCompetencies';
-import KeyProjects from './components/KeyProjects';
-import Education from './components/Education';
-import Contact from './components/Contact';
 import { ResumeData, ResumeDataSchema } from './types';
 import { AlertCircle } from 'lucide-react';
+
+const Experience = lazy(() => import('./components/Experience'));
+const CoreCompetencies = lazy(() => import('./components/CoreCompetencies'));
+const KeyProjects = lazy(() => import('./components/KeyProjects'));
+const Education = lazy(() => import('./components/Education'));
+const Contact = lazy(() => import('./components/Contact'));
+
+const SectionLoader = () => (
+  <div className="py-12 text-center text-muted-foreground">Loading section...</div>
+);
 
 function App() {
   const [resumeData, setResumeData] = useState<ResumeData | null>(null);
@@ -17,18 +22,22 @@ function App() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     const fetchData = async () => {
       try {
-        const response = await fetch('./data.json');
+        const response = await fetch('./data.json', { signal: controller.signal });
         if (!response.ok) {
           throw new Error(`Failed to fetch data: ${response.status} ${response.statusText}`);
         }
         const jsonData = await response.json();
-        
-        // Validate data with Zod
+
         const validatedData = ResumeDataSchema.parse(jsonData);
         setResumeData(validatedData);
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          return;
+        }
         console.error('Error loading resume data:', err);
         setError(err instanceof Error ? err.message : 'An unknown error occurred while loading data.');
       } finally {
@@ -37,6 +46,10 @@ function App() {
     };
 
     fetchData();
+
+    return () => {
+      controller.abort();
+    };
   }, []);
 
   if (loading) {
@@ -61,7 +74,7 @@ function App() {
           <p className="text-muted-foreground mb-6">
             {error || 'Unable to load portfolio data. Please try again later.'}
           </p>
-          <button 
+          <button
             onClick={() => window.location.reload()}
             className="px-6 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
           >
@@ -78,19 +91,34 @@ function App() {
       <main>
         <Hero data={resumeData.personal_info} />
         <About data={resumeData.personal_info} achievements={resumeData.key_achievements} />
-        <Experience experiences={resumeData.work_experience} />
-        <CoreCompetencies
-          competencies={resumeData.core_competencies}
-          technicalExpertise={resumeData.technical_expertise}
-          leadershipSkills={resumeData.leadership_skills}
-        />
-        <KeyProjects projects={resumeData.key_projects} />
-        <Education 
-          education={resumeData.education} 
-          programs={resumeData.postgraduate_programs}
-          certifications={resumeData.professional_certifications}
-        />
-        <Contact data={resumeData.personal_info} />
+
+        <Suspense fallback={<SectionLoader />}>
+          <Experience experiences={resumeData.work_experience} />
+        </Suspense>
+
+        <Suspense fallback={<SectionLoader />}>
+          <CoreCompetencies
+            competencies={resumeData.core_competencies}
+            technicalExpertise={resumeData.technical_expertise}
+            leadershipSkills={resumeData.leadership_skills}
+          />
+        </Suspense>
+
+        <Suspense fallback={<SectionLoader />}>
+          <KeyProjects projects={resumeData.key_projects} />
+        </Suspense>
+
+        <Suspense fallback={<SectionLoader />}>
+          <Education
+            education={resumeData.education}
+            programs={resumeData.postgraduate_programs}
+            certifications={resumeData.professional_certifications}
+          />
+        </Suspense>
+
+        <Suspense fallback={<SectionLoader />}>
+          <Contact data={resumeData.personal_info} />
+        </Suspense>
       </main>
     </div>
   );

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -30,6 +30,8 @@ const About: React.FC<AboutProps> = ({ data, achievements }) => {
                     src={profileImage} 
                     alt={data.full_name}
                     className="w-full h-full object-cover"
+                    loading="lazy"
+                    decoding="async"
                   />
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Reduce initial JS payload so above-the-fold content (`Header`, `Hero`, `About`) renders faster and improves time-to-interactive.
- Avoid unnecessary work when components unmount during data fetch to prevent wasted renders and potential memory usage.
- Decrease upfront image cost for the About profile to improve initial paint and bandwidth usage.

### Description
- Added route/section-level code splitting by replacing direct imports with `React.lazy` + `Suspense` for `Experience`, `CoreCompetencies`, `KeyProjects`, `Education`, and `Contact` in `src/App.tsx`.
- Introduced a small shared fallback loader component `SectionLoader` and wrapped each deferred section in `<Suspense fallback={<SectionLoader />}>` to keep UX consistent while chunks load.
- Hardened data fetching in `src/App.tsx` with an `AbortController` and cleanup to avoid setting state after unmount and to cancel in-flight fetches.
- Optimized the About profile image in `src/components/About.tsx` by adding `loading="lazy"` and `decoding="async"` attributes.

### Testing
- Ran `npm run build` and verified a successful production build with smaller initial bundle and deferred section chunks created (build completed successfully).
- Ran `npm run lint` and there were no lint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee616742b8832199967a5e86ac4224)