### PR TITLE
Enhance portfolio dashboard and project metrics

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -230,7 +230,10 @@
       "client": "VPRA",
       "achievement": "Leading the delivery phases of a critical rail corridor expansion.",
       "scope": "Construction of a series of upgraded and new bridges to increase rail capacity and reliability in the corridor.",
-      "timeframe": "2025 - Present"
+      "timeframe": "2025 - Present",
+      "contract_type": "PDB",
+      "sector": "rail",
+      "region": "usa"
     },
     {
       "name": "Susquehanna River Bridge CMAR Project",
@@ -241,7 +244,10 @@
       "client": "Amtrak",
       "achievement": "Managing all commercial activities including contracts, procurement, project controls, communications, and financial management",
       "scope": "Replacement of the existing Susquehanna River Bridge with two new parallel, 1mile fixed-span structures featuring a total of four tracks",
-      "timeframe": "Jun 2024 - Present"
+      "timeframe": "Jun 2024 - Present",
+      "contract_type": "CMAR",
+      "sector": "rail",
+      "region": "usa"
     },
     {
       "name": "SR-400 Express Lanes P3 Project",
@@ -252,7 +258,10 @@
       "client": "GDOT",
       "achievement": "Excelled in capture of major projects, enhancing proposal quality and securing new business, contributed to enhancing proposals, and facilitated stakeholder meetings to ensure transparency and maintain strong client relationships",
       "scope": "16-mile express managed lanes",
-      "timeframe": "Jun 2023 - Jun 2024"
+      "timeframe": "Jun 2023 - Jun 2024",
+      "contract_type": "P3",
+      "sector": "highway",
+      "region": "usa"
     },
     {
       "name": "I-10 Calcasieu River Bridge P3 Project",
@@ -263,7 +272,10 @@
       "client": "LADOTD",
       "achievement": "Excelled in capture of major projects, enhancing proposal quality and securing new business, contributed to enhancing proposals, and facilitated stakeholder meetings to ensure transparency and maintain strong client relationships",
       "scope": "New 8-lane bridge and approaches along a 5.5-mile I-10 corridor",
-      "timeframe": "Jun 2023 - Jun 2024"
+      "timeframe": "Jun 2023 - Jun 2024",
+      "contract_type": "P3",
+      "sector": "highway",
+      "region": "usa"
     },
     {
       "name": "TXDOT Grand Parkway Segments H, I-1, and I-2 DB Project",
@@ -274,7 +286,10 @@
       "client": "TXDOT",
       "achievement": "Successfully delivered all RFC design packages for the TxDOT $950M Design-Build Grand Parkway Segments H, I-1, and I-2 Project, managed over 300 design change modifications, enhancing project safety and cost-effectiveness, provided leadership and strategic direction as Construction Technical Office Manager**, supporting the US management team, and collaborated closely with joint venture partners, ensuring adherence to the Design-Build contract with TxDOT",
       "scope": "58-mile toll road infrastructure",
-      "timeframe": "Oct 2017 - Feb 2022"
+      "timeframe": "Oct 2017 - Feb 2022",
+      "contract_type": "DB",
+      "sector": "highway",
+      "region": "usa"
     },
     {
       "name": "INDOT I-69 Section 5 P3 Project",
@@ -285,7 +300,10 @@
       "client": "INDOT",
       "achievement": "Led the technical and commercial management ensuring successful coordination of design-build activities, project controls, and procurement",
       "location": "Bloomington IN, USA",
-      "timeframe": "Aug 2014 - Oct 2017"
+      "timeframe": "Aug 2014 - Oct 2017",
+      "contract_type": "P3",
+      "sector": "highway",
+      "region": "usa"
     },
     {
       "name": "Tramway Corridor Ayacucho Avenue",
@@ -296,7 +314,10 @@
       "client": "Metro de Medellín",
       "scope": "2-km tram infrastructure with cut & cover structures",
       "location": "Medellín, Colombia",
-      "achievement": "Implementation of cut & cover construction methodology"
+      "achievement": "Implementation of cut & cover construction methodology",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "south-america"
     },
     {
       "name": "High Speed Rail Zizurkil to Andoain",
@@ -307,7 +328,10 @@
       "scope": "5-km tunnel (NATM) and 200-meter concrete bridge",
       "location": "Basque Country, Spain",
       "client": "ADIF",
-      "achievement": "Design of 5km tunnel using NATM methodology"
+      "achievement": "Design of 5km tunnel using NATM methodology",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "High Speed Rail Nudo de Venta de Baños",
@@ -318,7 +342,10 @@
       "scope": "Two pre-stressed concrete bridges (1,330m and 1,128m)",
       "client": "ADIF",
       "location": "Castilla y León, Spain",
-      "achievement": "Delivered major pre-stressed concrete bridge structures, contributed to high-speed rail network expansion, and implemented advanced concrete construction techniques"
+      "achievement": "Delivered major pre-stressed concrete bridge structures, contributed to high-speed rail network expansion, and implemented advanced concrete construction techniques",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "High Speed Rail Andoain to Urnieta",
@@ -329,7 +356,10 @@
       "scope": "340-meter pre-stressed concrete bridge, 200-meter prefabricated beams bridge, 2-km tunnel (NATM)",
       "location": "Basque Country, Spain",
       "client": "ADIF",
-      "achievement": "Constructed complex bridge structures, implemented NATM tunneling technology, and integrated multiple construction methodologies"
+      "achievement": "Constructed complex bridge structures, implemented NATM tunneling technology, and integrated multiple construction methodologies",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "High Speed Rail Cabezón de Pisuerga to San Martín de Valvení",
@@ -339,7 +369,10 @@
       "company": "Team Engineering for Ferrovial",
       "scope": "2-km tunnel and two prefabricated bridges",
       "location": "Castile and León, Spain",
-      "achievement": "Successfully completed tunnel construction, installed prefabricated bridges, and developed high-speed rail corridors"
+      "achievement": "Successfully completed tunnel construction, installed prefabricated bridges, and developed high-speed rail corridors",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "High-Speed Rail Legutiano to Escoriatza",
@@ -347,7 +380,10 @@
       "role": "Senior Project Manager",
       "company": "Fonorte",
       "scope": "Two parallel 2-km tunnel (NATM)",
-      "timeframe": "Nov 2008 - Jun 2010"
+      "timeframe": "Nov 2008 - Jun 2010",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "Gernika Water Pipeline Construction",
@@ -357,7 +393,10 @@
       "company": "Construction contractor",
       "scope": "7-km water pipeline including 700-meter pipe jacking",
       "location": "Gernika, Basque Country, Spain",
-      "achievement": "Successfully completed pipe jacking operations, enhanced water infrastructure systems, and applied trenchless construction methodologies"
+      "achievement": "Successfully completed pipe jacking operations, enhanced water infrastructure systems, and applied trenchless construction methodologies",
+      "contract_type": "DBB",
+      "sector": "other",
+      "region": "europe"
     },
     {
       "name": "High-Speed Rail Cornellà del Terri to Vilademuls",
@@ -365,7 +404,10 @@
       "role": "Project Manager",
       "company": "Sacyr",
       "scope": "Tunnels and pre-stressed concrete bridges",
-      "timeframe": "Sep 2005 - Nov 2008"
+      "timeframe": "Sep 2005 - Nov 2008",
+      "contract_type": "DBB",
+      "sector": "rail",
+      "region": "europe"
     },
     {
       "name": "Urban Road BI-625 Section IV Project",
@@ -375,7 +417,10 @@
       "company": "Construction contractor",
       "scope": "3-km high capacity to urban road conversion with demolitions, contaminated material excavation, drainage systems",
       "location": "Basque Country, Spain",
-      "achievement": "Transformed urban road infrastructure, managed environmental remediation and contaminated materials, and relocated and installed utility infrastructure"
+      "achievement": "Transformed urban road infrastructure, managed environmental remediation and contaminated materials, and relocated and installed utility infrastructure",
+      "contract_type": "DBB",
+      "sector": "highway",
+      "region": "europe"
     },
     {
       "name": "Toll Road Intersection R-3/M-50",
@@ -385,7 +430,10 @@
       "company": "Construction contractor",
       "scope": "Intersection of two toll roads with seven prefabricated bridges",
       "location": "Madrid, Spain",
-      "achievement": "Constructed complex highway intersections, installed multiple prefabricated bridges, and managed traffic during construction"
+      "achievement": "Constructed complex highway intersections, installed multiple prefabricated bridges, and managed traffic during construction",
+      "contract_type": "DBB",
+      "sector": "highway",
+      "region": "europe"
     },
     {
       "name": "Toll Road AP1 Eibar to Bergara",
@@ -394,7 +442,10 @@
       "role": "Construction Supervision Manager",
       "location": "Basque Country, Spain",
       "company": "Prointec",
-      "timeframe": "Jan 2003 - Sep 2005"
+      "timeframe": "Jan 2003 - Sep 2005",
+      "contract_type": "DBB",
+      "sector": "highway",
+      "region": "europe"
     },
     {
       "name": "Urumea Highway Martutene to Astigarraga",
@@ -402,7 +453,52 @@
       "scope": "6-km highway",
       "role": "Construction Supervision Manager",
       "company": "Prointec",
-      "timeframe": "Jan 2003 - Sep 2005"
+      "timeframe": "Jan 2003 - Sep 2005",
+      "contract_type": "DBB",
+      "sector": "highway",
+      "region": "europe"
+    },
+    {
+      "name": "East Harbour Transit Hub Alliance",
+      "value": "$0.5B CAD",
+      "role": "Project Manager Early Works",
+      "company": "Rail Connect Partners, Bird Construction and AtkinsRéalis JV",
+      "location": "Toronto, Ontario, Canada",
+      "client": "Metrolinx",
+      "achievement": "Delivering one of Canada’s first major transit projects under an alliance contracting model.",
+      "scope": "New interchange station connecting GO Transit Lakeshore East and Stouffville lines with the future Ontario Line, including six tracks, three island platforms, concourses, bridge and corridor works, and future Broadview Avenue extension interface.",
+      "timeframe": "2022 - 2023",
+      "contract_type": "Alliance",
+      "sector": "rail",
+      "region": "canada"
+    },
+    {
+      "name": "Scarborough Subway Extension SRS PDB",
+      "value": "$5.7B CAD",
+      "role": "SME in Bid phase",
+      "company": "Kiewit and AtkinsRéalis JV",
+      "location": "Toronto, Ontario, Canada",
+      "client": "Metrolinx",
+      "achievement": "Advancing the stations, rail, and systems package for a major extension of TTC Line 2 into Scarborough.",
+      "scope": "Design and construction of stations, rail, and systems for the 7.8 km Scarborough Subway Extension, including three new stations, rail systems, operating systems, emergency exit buildings, traction power, and Kennedy Station modifications.",
+      "timeframe": "2022 - 2022",
+      "contract_type": "PDB",
+      "sector": "rail",
+      "region": "canada"
+    },
+    {
+      "name": "Ontario Line Elevated Guideway and Stations PDB",
+      "value": "$1.5B CAD",
+      "role": "Bid Director RFQ",
+      "company": "Bird Construction and AtkinsRéalis JV",
+      "location": "Toronto, Ontario, Canada",
+      "client": "Metrolinx",
+      "achievement": "Delivering a key elevated section of the Ontario Line under a progressive design-build model.",
+      "scope": "Design and construction of approximately 3 km of elevated guideway, five elevated stations, one emergency exit building, and interfaces with the maintenance and storage facility, Eglinton Crosstown LRT, and existing Metrolinx rail corridor.",
+      "timeframe": "2023 - 2023",
+      "contract_type": "PDB",
+      "sector": "rail",
+      "region": "canada"
     }
   ],
   "key_achievements": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import About from './components/About';
 import { ResumeData, ResumeDataSchema } from './types';
 import { AlertCircle } from 'lucide-react';
 
+const PortfolioSnapshot = lazy(() => import('./components/PortfolioSnapshot'));
 const Experience = lazy(() => import('./components/Experience'));
 const CoreCompetencies = lazy(() => import('./components/CoreCompetencies'));
 const KeyProjects = lazy(() => import('./components/KeyProjects'));
@@ -90,6 +91,11 @@ function App() {
       <Header />
       <main>
         <Hero data={resumeData.personal_info} />
+
+        <Suspense fallback={<SectionLoader />}>
+          <PortfolioSnapshot data={resumeData} />
+        </Suspense>
+
         <About data={resumeData.personal_info} achievements={resumeData.key_achievements} />
 
         <Suspense fallback={<SectionLoader />}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,9 @@ const Header: React.FC = () => {
               <a href="#hero" onClick={handleLinkClick} className="text-foreground hover:text-primary transition-colors">
                 Home
               </a>
+              <a href="#snapshot" onClick={handleLinkClick} className="text-foreground hover:text-primary transition-colors">
+                Snapshot
+              </a>
               <a href="#about" onClick={handleLinkClick} className="text-foreground hover:text-primary transition-colors">
                 About
               </a>
@@ -65,6 +68,9 @@ const Header: React.FC = () => {
           <div id="mobile-menu" className="md:hidden mt-4 space-y-2 bg-background p-4 rounded-lg shadow-lg">
             <a href="#hero" onClick={handleLinkClick} className="block w-full text-left text-foreground hover:text-primary py-2">
               Home
+            </a>
+            <a href="#snapshot" onClick={handleLinkClick} className="block w-full text-left text-foreground hover:text-primary py-2">
+              Snapshot
             </a>
             <a href="#about" onClick={handleLinkClick} className="block w-full text-left text-foreground hover:text-primary py-2">
               About

--- a/src/components/KeyProjects.tsx
+++ b/src/components/KeyProjects.tsx
@@ -5,7 +5,8 @@ import { FaRoad, FaHardHat } from 'react-icons/fa';
 import { TbBuildingTunnel } from 'react-icons/tb';
 import { MdLocationOn, MdClose } from 'react-icons/md';
 import { Button } from './ui/button';
-import { ResumeData } from '../types';
+import { ContractType, ResumeData } from '../types';
+import { enrichProjects, ProjectWithMetrics, RegionKey, SectorKey } from '../lib/portfolioMetrics';
 
 const ProjectMaps = React.lazy(() => import('./ProjectMaps'));
 
@@ -15,74 +16,138 @@ interface KeyProjectsProps {
   projects: Project[];
 }
 
-type ProjectCategoryKey = 'highways' | 'railways' | 'miscellaneous';
-type FilterKey = 'all' | ProjectCategoryKey;
-
 interface ProjectInfo {
-  categoryKey: ProjectCategoryKey;
   categoryLabel: string;
   icon: JSX.Element;
 }
 
-const filterConfig: Record<FilterKey, { label: string }> = {
-  all: { label: 'All Projects' },
-  highways: { label: 'Highways' },
-  railways: { label: 'Railways' },
-  miscellaneous: { label: 'Miscellaneous' },
+type SectorFilterKey = 'all' | SectorKey;
+type ContractFilterKey = 'all' | ContractType;
+type RegionFilterKey = 'all' | RegionKey;
+
+const sectorFilterConfig: Record<SectorFilterKey, { label: string }> = {
+  all: { label: 'All Sectors' },
+  rail: { label: 'Rail & Transit' },
+  highway: { label: 'Highways & Bridges' },
+  other: { label: 'Other Infrastructure' },
 };
 
-const getProjectInfo = (project: Project): ProjectInfo => {
+const contractFilterConfig: Record<ContractFilterKey, { label: string }> = {
+  all: { label: 'All Contracts' },
+  P3: { label: 'P3' },
+  PDB: { label: 'PDB' },
+  DB: { label: 'DB' },
+  DBB: { label: 'DBB' },
+  CMAR: { label: 'CMAR' },
+  Alliance: { label: 'Alliance' },
+  Other: { label: 'Other' },
+};
+
+const regionFilterConfig: Record<RegionFilterKey, { label: string }> = {
+  all: { label: 'All Regions' },
+  usa: { label: 'United States' },
+  canada: { label: 'Canada' },
+  europe: { label: 'Europe' },
+  'south-america': { label: 'South America' },
+  other: { label: 'Other' },
+};
+
+const getProjectInfo = (project: ProjectWithMetrics): ProjectInfo => {
   const text = `${project.name} ${project.scope ?? ''}`.toLowerCase();
 
-  if (text.includes('rail') || text.includes('tram') || text.includes('track')) {
-    return { categoryKey: 'railways', categoryLabel: 'High-Speed Rail', icon: <PiTrain /> };
+  if (project.sectorKey === 'rail') {
+    return { categoryLabel: 'Rail & Transit', icon: <PiTrain /> };
   }
 
   if (text.includes('bridge')) {
-    return { categoryKey: 'highways', categoryLabel: 'Bridge Construction', icon: <GiSuspensionBridge /> };
+    return { categoryLabel: 'Bridge Construction', icon: <GiSuspensionBridge /> };
   }
 
-  if (
-    text.includes('highway') ||
-    text.includes('interstate') ||
-    text.includes('i-') ||
-    text.includes('sr-') ||
-    text.includes('express') ||
-    text.includes('parkway') ||
-    text.includes('toll') ||
-    text.includes('road') ||
-    text.includes('lane')
-  ) {
-    return { categoryKey: 'highways', categoryLabel: 'Highway Construction', icon: <FaRoad /> };
+  if (project.sectorKey === 'highway') {
+    return { categoryLabel: 'Highway Construction', icon: <FaRoad /> };
   }
 
   if (text.includes('tunnel')) {
-    return { categoryKey: 'miscellaneous', categoryLabel: 'Tunneling', icon: <TbBuildingTunnel /> };
+    return { categoryLabel: 'Tunneling', icon: <TbBuildingTunnel /> };
   }
 
-  return { categoryKey: 'miscellaneous', categoryLabel: 'Infrastructure', icon: <FaHardHat /> };
+  return { categoryLabel: 'Infrastructure', icon: <FaHardHat /> };
 };
 
-const FILTER_KEYS: FilterKey[] = ['all', 'highways', 'railways', 'miscellaneous'];
+const SECTOR_ORDER: SectorKey[] = ['rail', 'highway', 'other'];
+const CONTRACT_ORDER: ContractType[] = ['P3', 'PDB', 'DB', 'DBB', 'CMAR', 'Alliance', 'Other'];
+const REGION_ORDER: RegionKey[] = ['usa', 'canada', 'europe', 'south-america', 'other'];
 
 const KeyProjects: React.FC<KeyProjectsProps> = ({ projects }) => {
-  const [selectedProject, setSelectedProject] = useState<(Project & ProjectInfo) | null>(null);
-  const [activeFilter, setActiveFilter] = useState<FilterKey>('all');
+  const [selectedProject, setSelectedProject] = useState<(ProjectWithMetrics & ProjectInfo) | null>(null);
+  const [activeSector, setActiveSector] = useState<SectorFilterKey>('all');
+  const [activeContract, setActiveContract] = useState<ContractFilterKey>('all');
+  const [activeRegion, setActiveRegion] = useState<RegionFilterKey>('all');
 
   const projectsWithInfo = useMemo(() => {
-    return projects.map((project) => ({ ...project, ...getProjectInfo(project) }));
+    return enrichProjects(projects).map((project) => ({ ...project, ...getProjectInfo(project) }));
   }, [projects]);
 
-  const filteredProjects = useMemo(() => {
-    if (activeFilter === 'all') return projectsWithInfo;
-    return projectsWithInfo.filter((project) => project.categoryKey === activeFilter);
-  }, [projectsWithInfo, activeFilter]);
+  const filterCounts = useMemo(() => {
+    return {
+      sectors: projectsWithInfo.reduce<Record<string, number>>((counts, project) => {
+        counts[project.sectorKey] = (counts[project.sectorKey] ?? 0) + 1;
+        return counts;
+      }, {}),
+      contracts: projectsWithInfo.reduce<Record<string, number>>((counts, project) => {
+        counts[project.contractType] = (counts[project.contractType] ?? 0) + 1;
+        return counts;
+      }, {}),
+      regions: projectsWithInfo.reduce<Record<string, number>>((counts, project) => {
+        counts[project.regionKey] = (counts[project.regionKey] ?? 0) + 1;
+        return counts;
+      }, {}),
+    };
+  }, [projectsWithInfo]);
 
-  const handleProjectKeyDown = (e: React.KeyboardEvent, project: Project & ProjectInfo) => {
+  const sectorFilterKeys = useMemo<SectorFilterKey[]>(() => {
+    return ['all', ...SECTOR_ORDER.filter((key) => (filterCounts.sectors[key] ?? 0) > 0)];
+  }, [filterCounts.sectors]);
+
+  const contractFilterKeys = useMemo<ContractFilterKey[]>(() => {
+    return ['all', ...CONTRACT_ORDER.filter((key) => (filterCounts.contracts[key] ?? 0) > 0)];
+  }, [filterCounts.contracts]);
+
+  const regionFilterKeys = useMemo<RegionFilterKey[]>(() => {
+    return ['all', ...REGION_ORDER.filter((key) => (filterCounts.regions[key] ?? 0) > 0)];
+  }, [filterCounts.regions]);
+
+  const filteredProjects = useMemo(() => {
+    return projectsWithInfo.filter((project) => {
+      const matchesSector = activeSector === 'all' || project.sectorKey === activeSector;
+      const matchesContract = activeContract === 'all' || project.contractType === activeContract;
+      const matchesRegion = activeRegion === 'all' || project.regionKey === activeRegion;
+      return matchesSector && matchesContract && matchesRegion;
+    });
+  }, [projectsWithInfo, activeSector, activeContract, activeRegion]);
+
+  const filterSummary = useMemo(() => {
+    const contractCounts = filteredProjects.reduce<Record<string, number>>((counts, project) => {
+      counts[project.contractType] = (counts[project.contractType] ?? 0) + 1;
+      return counts;
+    }, {});
+
+    return Object.entries(contractCounts)
+      .map(([contract, count]) => `${contract}: ${count}`)
+      .join(' | ');
+  }, [filteredProjects]);
+
+  const handleProjectKeyDown = (e: React.KeyboardEvent, project: ProjectWithMetrics & ProjectInfo) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       setSelectedProject(project);
     }
+  };
+
+  const clearFilters = () => {
+    setActiveSector('all');
+    setActiveContract('all');
+    setActiveRegion('all');
   };
 
   return (
@@ -95,27 +160,71 @@ const KeyProjects: React.FC<KeyProjectsProps> = ({ projects }) => {
               Key Projects
             </h2>
             <p className="text-muted-foreground mt-6 text-lg max-w-3xl mx-auto">
-              Multibillion-dollar infrastructure projects spanning rail, highway, and bridge construction across three continents
+              Multibillion-dollar infrastructure projects spanning rail, highway, and bridge construction across North America, Europe, and South America
             </p>
           </div>
 
-          {/* Category Filter Tabs */}
-          <div className="flex flex-wrap justify-center gap-3 mb-8">
-            {FILTER_KEYS.map((key) => (
-              <Button
-                key={key}
-                variant={activeFilter === key ? 'default' : 'outline'}
-                onClick={() => setActiveFilter(key)}
-                className="min-w-[130px]"
-              >
-                {filterConfig[key].label}
-              </Button>
-            ))}
+          {/* Portfolio Filters */}
+          <div className="space-y-4 mb-8">
+            <div className="flex flex-wrap justify-center gap-3">
+              {sectorFilterKeys.map((key) => (
+                <Button
+                  key={key}
+                  variant={activeSector === key ? 'default' : 'outline'}
+                  onClick={() => setActiveSector(key)}
+                  className="min-w-[130px]"
+                >
+                  {sectorFilterConfig[key].label}
+                  {key !== 'all' && filterCounts.sectors[key] ? ` (${filterCounts.sectors[key]})` : ''}
+                </Button>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap justify-center gap-2">
+              {contractFilterKeys.map((key) => (
+                <Button
+                  key={key}
+                  variant={activeContract === key ? 'default' : 'outline'}
+                  onClick={() => setActiveContract(key)}
+                  size="sm"
+                >
+                  {contractFilterConfig[key].label}
+                  {key !== 'all' && filterCounts.contracts[key] ? ` (${filterCounts.contracts[key]})` : ''}
+                </Button>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap justify-center gap-2">
+              {regionFilterKeys.map((key) => (
+                <Button
+                  key={key}
+                  variant={activeRegion === key ? 'default' : 'outline'}
+                  onClick={() => setActiveRegion(key)}
+                  size="sm"
+                >
+                  {regionFilterConfig[key].label}
+                  {key !== 'all' && filterCounts.regions[key] ? ` (${filterCounts.regions[key]})` : ''}
+                </Button>
+              ))}
+            </div>
+
+            <p className="text-center text-sm text-muted-foreground">
+              Showing {filteredProjects.length} of {projectsWithInfo.length} projects
+              {filterSummary ? ` | ${filterSummary}` : ''}
+            </p>
+            {(activeSector !== 'all' || activeContract !== 'all' || activeRegion !== 'all') && (
+              <div className="flex justify-center">
+                <Button variant="ghost" size="sm" onClick={clearFilters}>
+                  Clear filters
+                </Button>
+              </div>
+            )}
           </div>
 
           {/* Projects Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
-            {filteredProjects.map((project) => (
+          {filteredProjects.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
+              {filteredProjects.map((project) => (
               <div
                 key={project.name}
                 className="group bg-background rounded-xl p-6 border border-border shadow-sm hover:shadow-lg transition-all duration-300 hover:border-primary/50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/50"
@@ -140,6 +249,9 @@ const KeyProjects: React.FC<KeyProjectsProps> = ({ projects }) => {
                 <div className="mb-4">
                   <span className="inline-block px-2 py-1 bg-primary/10 border border-primary/20 rounded text-primary text-xs font-medium mb-2">
                     {project.categoryLabel}
+                  </span>
+                  <span className="inline-block ml-2 px-2 py-1 bg-muted border border-border rounded text-muted-foreground text-xs font-medium mb-2">
+                    {project.contractType}
                   </span>
                   <h3 className="text-lg font-semibold text-foreground mb-2 line-clamp-2 group-hover:text-primary transition-colors">
                     {project.name}
@@ -167,8 +279,17 @@ const KeyProjects: React.FC<KeyProjectsProps> = ({ projects }) => {
                   </div>
                 )}
               </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mb-12 rounded-lg border border-border bg-background p-8 text-center">
+              <p className="text-lg font-semibold text-foreground">No projects match these filters.</p>
+              <p className="mt-2 text-sm text-muted-foreground">Try clearing one filter or returning to all projects.</p>
+              <Button className="mt-4" variant="outline" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -212,7 +333,12 @@ const KeyProjects: React.FC<KeyProjectsProps> = ({ projects }) => {
                   </div>
                   <div>
                     <h4 className="text-sm font-semibold text-muted-foreground mb-1">Company</h4>
-                    <p className="text-foreground">{selectedProject.company}</p>
+                      <p className="text-foreground">{selectedProject.company}</p>
+                  </div>
+
+                  <div>
+                    <h4 className="text-sm font-semibold text-muted-foreground mb-1">Contract Type</h4>
+                    <p className="text-foreground">{selectedProject.contractType}</p>
                   </div>
 
                   {selectedProject.client && (

--- a/src/components/PortfolioSnapshot.tsx
+++ b/src/components/PortfolioSnapshot.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { BriefcaseBusiness, DollarSign, GitBranch, MapPinned, Route, TrainFront } from 'lucide-react';
+import { ResumeData } from '../types';
+import { buildPortfolioMetrics, formatYears } from '../lib/portfolioMetrics';
+
+interface PortfolioSnapshotProps {
+  data: ResumeData;
+}
+
+const chartColors = ['#0057a8', '#168aad', '#6a994e', '#f59e0b', '#7c3aed', '#64748b'];
+
+const formatProjectValue = (valueMillions: number | null | undefined) => {
+  if (!valueMillions) return 'N/A';
+  if (valueMillions >= 1000) return `$${(valueMillions / 1000).toFixed(1).replace(/\.0$/, '')}B`;
+  return `$${Math.round(valueMillions)}M`;
+};
+
+const PortfolioSnapshot: React.FC<PortfolioSnapshotProps> = ({ data }) => {
+  const metrics = useMemo(() => buildPortfolioMetrics(data), [data]);
+
+  const headlineStats = [
+    {
+      label: 'Career Experience',
+      value: `${formatYears(metrics.careerYears)} yrs`,
+      detail: 'Infrastructure leadership',
+      icon: BriefcaseBusiness,
+    },
+    {
+      label: 'Key Projects',
+      value: metrics.totalProjects.toString(),
+      detail: 'Major programs represented',
+      icon: Route,
+    },
+    {
+      label: 'Rail Portfolio',
+      value: metrics.railProjects.toString(),
+      detail: `${metrics.railYears} active project years`,
+      icon: TrainFront,
+    },
+    {
+      label: 'Highway & Bridges',
+      value: metrics.highwayProjects.toString(),
+      detail: `${metrics.highwayYears} active project years`,
+      icon: GitBranch,
+    },
+    {
+      label: 'Largest Project',
+      value: formatProjectValue(metrics.largestProject?.parsedValueMillions),
+      detail: metrics.largestProject?.name ?? 'Project value unavailable',
+      icon: DollarSign,
+    },
+    {
+      label: 'Regions',
+      value: metrics.regions.length.toString(),
+      detail: 'U.S., Canada, Europe, South America',
+      icon: MapPinned,
+    },
+  ];
+
+  return (
+    <section id="snapshot" className="py-16 sm:py-20 bg-muted/40">
+      <div className="container mx-auto px-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-10">
+            <h2 className="text-4xl md:text-5xl font-bold text-primary mb-4">
+              Portfolio Snapshot
+            </h2>
+            <p className="text-muted-foreground mt-6 text-lg max-w-3xl mx-auto">
+              A data-driven view of infrastructure delivery scale, sector depth, and contract exposure.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
+            {headlineStats.map((stat) => {
+              const Icon = stat.icon;
+              return (
+                <div key={stat.label} className="bg-background border border-border rounded-lg p-5 shadow-sm">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium text-muted-foreground">{stat.label}</p>
+                      <p className="text-3xl font-bold text-foreground mt-2">{stat.value}</p>
+                    </div>
+                    <span className="h-10 w-10 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+                      <Icon className="h-5 w-5" />
+                    </span>
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-3 line-clamp-2">{stat.detail}</p>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="bg-background border border-border rounded-lg p-5 shadow-sm lg:col-span-1">
+              <h3 className="text-lg font-semibold text-foreground mb-4">Projects by Contract</h3>
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={metrics.contractChart}
+                      dataKey="count"
+                      nameKey="name"
+                      innerRadius={58}
+                      outerRadius={92}
+                      paddingAngle={3}
+                    >
+                      {metrics.contractChart.map((entry, index) => (
+                        <Cell key={entry.key} fill={chartColors[index % chartColors.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {metrics.contractChart.map((item, index) => (
+                  <div key={item.key} className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: chartColors[index % chartColors.length] }}
+                    />
+                    <span>{item.name}: {item.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="bg-background border border-border rounded-lg p-5 shadow-sm lg:col-span-2">
+              <h3 className="text-lg font-semibold text-foreground mb-1">Portfolio Value by Category</h3>
+              <p className="text-sm text-muted-foreground mb-4">
+                USD-equivalent value across listed key projects, with total portfolio shown for context.
+              </p>
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={metrics.sectorChart} margin={{ top: 8, right: 12, left: 0, bottom: 24 }}>
+                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                    <XAxis dataKey="name" tick={{ fontSize: 12 }} interval={0} />
+                    <YAxis tick={{ fontSize: 12 }} tickFormatter={(value) => formatProjectValue(Number(value))} />
+                    <Tooltip formatter={(value) => [formatProjectValue(Number(value)), 'USD-equivalent value']} />
+                    <Bar dataKey="valueMillions" radius={[6, 6, 0, 0]}>
+                      {metrics.sectorChart.map((entry, index) => (
+                        <Cell key={entry.key} fill={chartColors[index % chartColors.length]} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PortfolioSnapshot;

--- a/src/components/ProjectMaps.tsx
+++ b/src/components/ProjectMaps.tsx
@@ -18,7 +18,7 @@ L.Icon.Default.mergeOptions({
   shadowUrl: markerShadow,
 });
 
-type RegionId = 'usa' | 'europe' | 'south-america' | 'global';
+type RegionId = 'usa' | 'canada' | 'europe' | 'south-america' | 'global';
 
 type LonLat = {
   lon: number;
@@ -37,9 +37,36 @@ interface RegionDefinition {
 interface ProjectLocationDefinition {
   keywords: string[];
   coords: LonLat;
-  regionId: RegionId;
+  regionId: Exclude<RegionId, 'global'>;
   label: string;
 }
+
+const REGION_FALLBACK_LOCATIONS: Record<Exclude<RegionId, 'global'>, ProjectLocationDefinition> = {
+  usa: {
+    keywords: ['usa'],
+    coords: { lon: -98.5795, lat: 39.8283 },
+    regionId: 'usa',
+    label: 'United States',
+  },
+  canada: {
+    keywords: ['canada'],
+    coords: { lon: -79.3832, lat: 43.6532 },
+    regionId: 'canada',
+    label: 'Toronto, Ontario',
+  },
+  europe: {
+    keywords: ['europe'],
+    coords: { lon: -3.70379, lat: 40.416775 },
+    regionId: 'europe',
+    label: 'Spain',
+  },
+  'south-america': {
+    keywords: ['south-america'],
+    coords: { lon: -75.563, lat: 6.244 },
+    regionId: 'south-america',
+    label: 'Colombia',
+  },
+};
 
 const REGION_DEFINITIONS: Record<RegionId, RegionDefinition> = {
   global: {
@@ -59,6 +86,16 @@ const REGION_DEFINITIONS: Record<RegionId, RegionDefinition> = {
       'Pins surface large-scale delivery and capture programs across Washington, DC, Georgia, Louisiana, Texas, and Indiana. Hover to preview, then click to review the full project brief.',
     center: [39.8283, -98.5795],
     zoom: 4,
+  },
+  canada: {
+    id: 'canada',
+    name: 'Canada',
+    summary:
+      'Toronto-region transit programs delivered through alliance and progressive design-build models.',
+    detail:
+      'Explore Metrolinx programs across the Toronto network, including East Harbour, Scarborough, and Ontario Line corridor interfaces.',
+    center: [43.6532, -79.3832],
+    zoom: 10,
   },
   europe: {
     id: 'europe',
@@ -118,6 +155,24 @@ const PROJECT_LOCATIONS: ProjectLocationDefinition[] = [
     coords: { lon: -86.526, lat: 39.165 },
     regionId: 'usa',
     label: 'Bloomington, IN',
+  },
+  {
+    keywords: ['east harbour'],
+    coords: { lon: -79.338, lat: 43.653 },
+    regionId: 'canada',
+    label: 'East Harbour, Toronto',
+  },
+  {
+    keywords: ['scarborough subway', 'scarborough subway extension', 'srs pdb'],
+    coords: { lon: -79.257, lat: 43.744 },
+    regionId: 'canada',
+    label: 'Scarborough, Toronto',
+  },
+  {
+    keywords: ['ontario line elevated', 'ontario line elevated guideway', 'ontario line'],
+    coords: { lon: -79.324, lat: 43.689 },
+    regionId: 'canada',
+    label: 'Ontario Line Corridor, Toronto',
   },
   {
     keywords: ['ayacucho', 'medell'],
@@ -193,13 +248,30 @@ const PROJECT_LOCATIONS: ProjectLocationDefinition[] = [
   },
 ];
 
-const REGION_IDS: RegionId[] = ['global', 'usa', 'europe', 'south-america'];
+const REGION_IDS: RegionId[] = ['global', 'usa', 'canada', 'europe', 'south-america'];
 
 const matchProjectToLocation = (project: Project): ProjectLocationDefinition | undefined => {
   const haystack = `${project.name} ${project.location ?? ''}`.toLowerCase();
-  return PROJECT_LOCATIONS.find((entry) =>
+  const explicitMatch = PROJECT_LOCATIONS.find((entry) =>
     entry.keywords.some((keyword) => haystack.includes(keyword)),
   );
+
+  if (explicitMatch) return explicitMatch;
+
+  if (haystack.includes('toronto') || haystack.includes('ontario, canada') || haystack.includes('metrolinx')) {
+    return {
+      keywords: ['toronto'],
+      coords: { lon: -79.3832, lat: 43.6532 },
+      regionId: 'canada',
+      label: 'Toronto, Ontario',
+    };
+  }
+
+  if (project.region && project.region !== 'other') {
+    return REGION_FALLBACK_LOCATIONS[project.region];
+  }
+
+  return undefined;
 };
 
 const MapUpdater: React.FC<{ center: LatLngExpression; zoom: number }> = ({ center, zoom }) => {
@@ -227,9 +299,14 @@ const ProjectMaps: React.FC<{ projects: Project[] }> = ({ projects }) => {
           ...project,
           coords: [match.coords.lat, match.coords.lon] as LatLngExpression,
           regionId: match.regionId,
+          mapLabel: match.label,
         };
       })
-      .filter((project): project is Project & { coords: LatLngExpression; regionId: RegionId } => project !== null);
+      .filter((project): project is Project & {
+        coords: LatLngExpression;
+        regionId: Exclude<RegionId, 'global'>;
+        mapLabel: string;
+      } => project !== null);
   }, [projects]);
 
   const activeRegionDef = REGION_DEFINITIONS[activeRegion];
@@ -243,7 +320,7 @@ const ProjectMaps: React.FC<{ projects: Project[] }> = ({ projects }) => {
       <div className="text-center mb-12 space-y-3">
         <h3 className="text-3xl font-semibold text-foreground">Interactive Project Atlas</h3>
         <p className="text-muted-foreground max-w-3xl mx-auto">
-          Explore projects on an interactive map. Select a region to zoom in and see the projects located there.
+          Explore projects on an interactive map. Select a region to zoom in across North America, Europe, and South America.
         </p>
       </div>
 
@@ -275,6 +352,7 @@ const ProjectMaps: React.FC<{ projects: Project[] }> = ({ projects }) => {
             <Marker key={`${project.name}-${project.regionId}`} position={project.coords}>
               <Popup>
                 <b>{project.name}</b><br />
+                {project.mapLabel}<br />
                 {project.location}
               </Popup>
             </Marker>

--- a/src/lib/portfolioMetrics.ts
+++ b/src/lib/portfolioMetrics.ts
@@ -1,0 +1,253 @@
+import { ContractType, ProjectRegion, ProjectSector, ResumeData } from '../types';
+
+export type SectorKey = ProjectSector;
+export type RegionKey = ProjectRegion;
+
+export type ProjectWithMetrics = ResumeData['key_projects'][number] & {
+  sectorKey: SectorKey;
+  sectorLabel: string;
+  contractType: ContractType;
+  regionKey: RegionKey;
+  regionLabel: string;
+  parsedValueMillions: number | null;
+};
+
+type ValueSectorKey = SectorKey | 'all';
+
+const CONTRACT_TYPES: ContractType[] = ['P3', 'PDB', 'DB', 'DBB', 'CMAR', 'Alliance', 'Other'];
+
+const SECTOR_LABELS: Record<SectorKey, string> = {
+  rail: 'Rail & Transit',
+  highway: 'Highway & Bridges',
+  other: 'Water & Utilities',
+};
+
+const VALUE_SECTOR_LABELS: Record<ValueSectorKey, string> = {
+  all: 'Total Portfolio',
+  ...SECTOR_LABELS,
+};
+
+const REGION_LABELS: Record<RegionKey, string> = {
+  usa: 'United States',
+  canada: 'Canada',
+  europe: 'Europe',
+  'south-america': 'South America',
+  other: 'Other',
+};
+
+const CAD_TO_USD = 0.7272;
+const EUR_TO_USD = 1.1626;
+
+const SECTOR_KEYS: SectorKey[] = ['rail', 'highway', 'other'];
+const REGION_KEYS: RegionKey[] = ['usa', 'canada', 'europe', 'south-america', 'other'];
+
+const parseDateToken = (value: string | undefined, fallbackYear = 2003) => {
+  if (!value) return fallbackYear;
+
+  if (/present/i.test(value)) {
+    const now = new Date();
+    return now.getFullYear() + now.getMonth() / 12;
+  }
+
+  const match = value.match(/(?:(\d{1,2})[./\s-])?(\d{4})/);
+  if (!match) return fallbackYear;
+
+  const month = match[1] ? Number(match[1]) - 1 : 0;
+  return Number(match[2]) + Math.max(month, 0) / 12;
+};
+
+export const parseDateRange = (range: string | undefined) => {
+  if (!range) return null;
+
+  const [startToken, endToken] = range.split(/\s*(?:-|–|—)\s*/);
+  const start = parseDateToken(startToken);
+  const end = endToken ? parseDateToken(endToken, start) : start;
+
+  return {
+    start,
+    end: Math.max(end, start),
+    years: Math.max(end - start, 0),
+  };
+};
+
+export const formatYears = (years: number) => {
+  if (years >= 10) return `${Math.round(years)}+`;
+  if (years >= 1) return years.toFixed(1).replace(/\.0$/, '');
+  return '<1';
+};
+
+export const getProjectSector = (project: ResumeData['key_projects'][number]): SectorKey => {
+  if (project.sector && SECTOR_KEYS.includes(project.sector)) {
+    return project.sector;
+  }
+
+  const text = `${project.name} ${project.scope ?? ''}`.toLowerCase();
+
+  if (/\b(rail|tram|track|transit|high-speed|subway|station|stations|guideway|lrt)\b/.test(text)) return 'rail';
+
+  if (
+    /\b(highway|interstate|express|parkway|toll|road|lane|bridge|corridor)\b/.test(text) ||
+    /\b(i-|sr-|ap1|r-3|m-50|bi-625)\b/.test(text)
+  ) {
+    return 'highway';
+  }
+
+  return 'other';
+};
+
+export const getProjectRegion = (project: ResumeData['key_projects'][number]): RegionKey => {
+  if (project.region && REGION_KEYS.includes(project.region)) {
+    return project.region;
+  }
+
+  const text = `${project.location ?? ''} ${project.name} ${project.client ?? ''} ${project.scope ?? ''}`.toLowerCase();
+
+  if (/\b(canada|ontario|toronto|metrolinx|scarborough|ontario line)\b/.test(text)) {
+    return 'canada';
+  }
+
+  if (/\b(usa|dc|ga|la|tx|in|washington|atlanta|louisiana|texas|indiana|houston|bloomington)\b/.test(text)) {
+    return 'usa';
+  }
+
+  if (/\b(spain|basque|castile|catalonia|madrid|gernika|girona|eibar|bergara|legutiano|andoain|urnieta|pisuerga)\b/.test(text)) {
+    return 'europe';
+  }
+
+  if (/\b(colombia|medellin|medellín)\b/.test(text)) return 'south-america';
+
+  return 'other';
+};
+
+export const getProjectContractType = (project: ResumeData['key_projects'][number]): ContractType => {
+  if (project.contract_type && CONTRACT_TYPES.includes(project.contract_type)) {
+    return project.contract_type;
+  }
+
+  const text = `${project.name} ${project.scope ?? ''} ${project.achievement ?? ''}`.toLowerCase();
+
+  if (/\bpdb\b|progressive design-build/.test(text)) return 'PDB';
+  if (/\bcmar\b/.test(text)) return 'CMAR';
+  if (/\bp3\b|public-private/.test(text)) return 'P3';
+  if (/\balliance\b/.test(text)) return 'Alliance';
+  if (/\bdb\b|design-build/.test(text)) return 'DB';
+
+  return 'Other';
+};
+
+export const parseProjectValueMillions = (value: string) => {
+  const normalized = value.replace(/,/g, '').trim();
+  const match = normalized.match(/([$€]|eur|cad)?\s*([\d.]+)\s*([mb])?/i);
+  if (!match) return null;
+
+  const amount = Number(match[2]);
+  if (!Number.isFinite(amount)) return null;
+
+  const unit = match[3]?.toLowerCase();
+  const millions = unit === 'b' ? amount * 1000 : amount;
+
+  if (/\bcad\b/i.test(normalized)) {
+    return millions * CAD_TO_USD;
+  }
+
+  if (/€|\beur\b/i.test(normalized)) {
+    return millions * EUR_TO_USD;
+  }
+
+  return millions;
+};
+
+export const enrichProjects = (projects: ResumeData['key_projects']): ProjectWithMetrics[] => {
+  return projects.map((project) => {
+    const sectorKey = getProjectSector(project);
+    const regionKey = getProjectRegion(project);
+
+    return {
+      ...project,
+      sectorKey,
+      sectorLabel: SECTOR_LABELS[sectorKey],
+      contractType: getProjectContractType(project),
+      regionKey,
+      regionLabel: REGION_LABELS[regionKey],
+      parsedValueMillions: parseProjectValueMillions(project.value),
+    };
+  });
+};
+
+const roundedMillions = (value: number) => Math.round(value);
+
+const getUniqueCoveredYears = (projects: ProjectWithMetrics[], sector: SectorKey) => {
+  const years = new Set<number>();
+
+  projects
+    .filter((project) => project.sectorKey === sector)
+    .forEach((project) => {
+      const range = parseDateRange(project.timeframe);
+      if (!range) return;
+
+      const startYear = Math.floor(range.start);
+      const endYear = Math.max(startYear, Math.ceil(range.end));
+      for (let year = startYear; year <= endYear; year += 1) {
+        years.add(year);
+      }
+    });
+
+  return years.size;
+};
+
+export const buildPortfolioMetrics = (data: ResumeData) => {
+  const projects = enrichProjects(data.key_projects);
+  const careerStart = Math.min(...data.work_experience.map((experience) => parseDateRange(experience.duration)?.start ?? 2003));
+  const careerEnd = Math.max(...data.work_experience.map((experience) => parseDateRange(experience.duration)?.end ?? careerStart));
+  const largestProject = projects.reduce<ProjectWithMetrics | null>((largest, project) => {
+    if (project.parsedValueMillions === null) return largest;
+    if (!largest || (largest.parsedValueMillions ?? 0) < project.parsedValueMillions) return project;
+    return largest;
+  }, null);
+
+  const valueSectorKeys: ValueSectorKey[] = ['all', ...SECTOR_KEYS];
+  const sectorChart = valueSectorKeys.map((sector) => {
+    const sectorProjects = sector === 'all'
+      ? projects
+      : projects.filter((project) => project.sectorKey === sector);
+
+    const valueMillions = sectorProjects.reduce((total, project) => total + (project.parsedValueMillions ?? 0), 0);
+
+    return {
+      key: sector,
+      name: VALUE_SECTOR_LABELS[sector],
+      count: sectorProjects.length,
+      valueMillions: roundedMillions(valueMillions),
+    };
+  }).filter((item) => item.count > 0);
+
+  const projectCountBySectorChart = SECTOR_KEYS.map((sector) => {
+    const sectorProjects = projects.filter((project) => project.sectorKey === sector);
+    return {
+      key: sector,
+      name: SECTOR_LABELS[sector],
+      count: sectorProjects.length,
+    };
+  }).filter((item) => item.count > 0);
+
+  const contractChart = CONTRACT_TYPES.map((contractType) => ({
+    key: contractType,
+    name: contractType,
+    count: projects.filter((project) => project.contractType === contractType).length,
+  })).filter((item) => item.count > 0);
+
+  return {
+    projects,
+    careerYears: careerEnd - careerStart,
+    totalProjects: projects.length,
+    railProjects: projects.filter((project) => project.sectorKey === 'rail').length,
+    highwayProjects: projects.filter((project) => project.sectorKey === 'highway').length,
+    railYears: getUniqueCoveredYears(projects, 'rail'),
+    highwayYears: getUniqueCoveredYears(projects, 'highway'),
+    largestProject,
+    regions: Array.from(new Set(projects.map((project) => project.regionKey).filter((region) => region !== 'other'))),
+    contractChart,
+    sectorChart,
+    projectCountBySectorChart,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,10 @@ export interface ResumeData {
     contribution?: string;
     achievement?: string;
     scope?: string;
+    timeframe?: string;
+    contract_type?: ContractType;
+    sector?: ProjectSector;
+    region?: ProjectRegion;
   }>;
   key_achievements: string[];
   technical_expertise: {
@@ -61,6 +65,10 @@ export interface ResumeData {
   };
   leadership_skills: string[];
 }
+
+export type ContractType = 'P3' | 'PDB' | 'DB' | 'DBB' | 'CMAR' | 'Alliance' | 'Other';
+export type ProjectSector = 'rail' | 'highway' | 'other';
+export type ProjectRegion = 'usa' | 'canada' | 'europe' | 'south-america' | 'other';
 
 export const ResumeDataSchema: z.ZodType<ResumeData> = z.object({
   personal_info: z.object({
@@ -113,6 +121,10 @@ export const ResumeDataSchema: z.ZodType<ResumeData> = z.object({
     contribution: z.string().optional(),
     achievement: z.string().optional(),
     scope: z.string().optional(),
+    timeframe: z.string().optional(),
+    contract_type: z.enum(['P3', 'PDB', 'DB', 'DBB', 'CMAR', 'Alliance', 'Other']).optional(),
+    sector: z.enum(['rail', 'highway', 'other']).optional(),
+    region: z.enum(['usa', 'canada', 'europe', 'south-america', 'other']).optional(),
   })),
   key_achievements: z.array(z.string()),
   technical_expertise: z.object({


### PR DESCRIPTION
## Summary
- Add an executive Portfolio Snapshot dashboard with contract and value metrics.
- Add structured sector, region, and contract metadata for key projects, including Canada/Toronto projects.
- Improve Key Projects filtering by sector, contract, and region with data-driven counts.
- Update the interactive project atlas with Canada support and region fallbacks.
- Normalize CAD and EUR values to USD-equivalent for portfolio value charts.
- Use DBB for the 12 previously unknown contract types.
- Clarify portfolio value chart categories with Total Portfolio and Water & Utilities.

## Validation
- npm run lint ✅
- npm run build ✅
- Data rollup check: 21 projects, contracts PDB 3 / CMAR 1 / P3 3 / DB 1 / DBB 12 / Alliance 1
- Region rollup: USA 6 / Canada 3 / Europe 11 / South America 1
- Sector rollup: Rail 12 / Highway 8 / Other 1

Note: build still reports the existing Tailwind warning for `duration-[250ms]`, but it does not block the build.